### PR TITLE
カスタムレスポンスを実装したよ

### DIFF
--- a/bot/prisma/migrations/20250111013628_add_response_table/migration.sql
+++ b/bot/prisma/migrations/20250111013628_add_response_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "Response" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "keyword" TEXT NOT NULL,
+    "response" TEXT NOT NULL,
+
+    CONSTRAINT "Response_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Response_guildId_keyword_key" ON "Response"("guildId", "keyword");

--- a/bot/prisma/schema.prisma
+++ b/bot/prisma/schema.prisma
@@ -44,3 +44,12 @@ model Timer {
   isCanceled   Boolean @default(false)
   scheduledAt  DateTime
 }
+
+model Response {
+  id           String @id @default(uuid())
+  guildId      String
+  keyword      String
+  response     String
+
+  @@unique([guildId, keyword])
+}

--- a/bot/src/commands/customresponse.ts
+++ b/bot/src/commands/customresponse.ts
@@ -1,0 +1,101 @@
+import { ICustomResponseService } from '@/services/CustomResponse';
+import { BotCommand } from '@/types/command';
+import {
+  CommandInteractionOptionResolver,
+  SlashCommandBuilder,
+} from 'discord.js';
+import { container } from 'tsyringe';
+
+const service = container.resolve<ICustomResponseService>(
+  'ICustomResponseService',
+);
+
+const command: BotCommand = {
+  builder: new SlashCommandBuilder()
+    .setName('customresponse')
+    .setDescription('カスタムレスポンスを設定します')
+    .addSubcommand((cmd) =>
+      cmd
+        .setName('add')
+        .setDescription('新たなカスタムレスポンスを設定します')
+        .addStringOption((opt) =>
+          opt
+            .setName('keyword')
+            .setDescription('キーワード')
+            .setRequired(true)
+            .setMinLength(1),
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName('response')
+            .setDescription('レスポンス')
+            .setRequired(true)
+            .setMinLength(1),
+        )
+        .addBooleanOption((opt) =>
+          opt
+            .setName('update')
+            .setDescription('既存の設定を上書きします')
+            .setRequired(false),
+        ),
+    )
+    .addSubcommand((cmd) =>
+      cmd
+        .setName('delete')
+        .setDescription('カスタムレスポンスを削除します')
+        .addStringOption((opt) =>
+          opt.setName('keyword').setDescription('キーワード').setRequired(true),
+        ),
+    ),
+  handler: async (interaction) => {
+    if (interaction.user.bot) return;
+    if (!interaction.guildId) {
+      await interaction.reply('このコマンドはサーバー専用コマンドだよ');
+      return;
+    }
+    const options = interaction.options as CommandInteractionOptionResolver;
+    const subcommand = options.getSubcommand(true);
+    if (subcommand === 'add') {
+      const keyword = options.getString('keyword', true);
+      const response = options.getString('response', true);
+      const update = options.getBoolean('update', false) ?? false;
+      if (update) {
+        await service.upsertResponseAsync(
+          keyword,
+          response,
+          interaction.guildId,
+        );
+        await interaction.reply('カスタムレスポンスを設定しました');
+        return;
+      } else {
+        const result = await service.registerResponseAsync(
+          keyword,
+          response,
+          interaction.guildId,
+        );
+        if (result) {
+          await interaction.reply('カスタムレスポンスを設定しました');
+        } else {
+          await interaction.reply(
+            'キーワードがすでに使用されています\n設定を上書きする場合には`update`を`true`にして実行してください',
+          );
+        }
+      }
+    } else if (subcommand === 'delete') {
+      const keyword = options.getString('keyword', true);
+      const result = await service.unregisterResponseAsync(
+        keyword,
+        interaction.guildId,
+      );
+      if (result) {
+        await interaction.reply('カスタムレスポンスを削除しました');
+      } else {
+        await interaction.reply(
+          '指定したキーワードに対するカスタムレスポンスは見つかりませんでした',
+        );
+      }
+    }
+  },
+};
+
+export default command;

--- a/bot/src/events/CustomResponse/messageCreate.ts
+++ b/bot/src/events/CustomResponse/messageCreate.ts
@@ -1,0 +1,29 @@
+import { ICustomResponseService } from '@/services/CustomResponse';
+import { BotEvent } from '@/types/event';
+import { Events, Message } from 'discord.js';
+import { container } from 'tsyringe';
+
+const service = container.resolve<ICustomResponseService>(
+  'ICustomResponseService',
+);
+
+const event: BotEvent = {
+  eventName: Events.MessageCreate,
+  once: false,
+  listener: async (message: Message) => {
+    if (message.author.bot) return;
+    if (!message.guildId) return;
+    if (!message.channel) return;
+
+    const splits = message.content.split(/\s/);
+    for (const split of splits) {
+      const response = await service.searchResponseAsync(
+        split,
+        message.guildId,
+      );
+      if (response) message.channel.send(response);
+    }
+  },
+};
+
+export default event;

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -11,6 +11,7 @@ import { ITimerService, TimerService } from '@/services/timer';
 import { WikiService } from '@/services/Wiki';
 import { MinecraftService } from '@/services/Minecraft';
 import { DriveService } from '@/services/Drive';
+import { CustomResponseService } from '@/services/CustomResponse';
 
 container.register(
   'DiscordClient',
@@ -23,6 +24,9 @@ container.register(
   { useClass: DriveService },
   { lifecycle: Lifecycle.Singleton },
 );
+container.register('ICustomResponseService', {
+  useClass: CustomResponseService,
+});
 container.register('IMinecraftService', { useClass: MinecraftService });
 container.register('IOmikujiService', { useClass: OmikujiService });
 container.register('IRoomService', { useClass: RoomService });

--- a/bot/src/scripts/deploy-command.ts
+++ b/bot/src/scripts/deploy-command.ts
@@ -23,6 +23,7 @@ container.register(
   { useClass: DriveService },
   { lifecycle: Lifecycle.Singleton },
 );
+container.register('ICustomResponseService', { useValue: {} });
 container.register('IOmikujiService', { useValue: {} });
 container.register('IRoomService', { useValue: {} });
 container.register('IEmojiService', { useValue: {} });

--- a/bot/src/services/CustomResponse/index.ts
+++ b/bot/src/services/CustomResponse/index.ts
@@ -1,0 +1,108 @@
+import { prisma } from '@/core/prisma';
+import { injectable } from 'tsyringe';
+
+interface ICustomResponseService {
+  searchResponseAsync(
+    keyword: string,
+    guildId: string,
+  ): Promise<string | undefined>;
+  registerResponseAsync(
+    keyword: string,
+    response: string,
+    guildId: string,
+  ): Promise<boolean>;
+  unregisterResponseAsync(keyword: string, guildId: string): Promise<boolean>;
+  upsertResponseAsync(
+    keyword: string,
+    response: string,
+    guildId: string,
+  ): Promise<void>;
+}
+
+@injectable()
+class CustomResponseService implements ICustomResponseService {
+  async searchResponseAsync(
+    keyword: string,
+    guildId: string,
+  ): Promise<string | undefined> {
+    const response = await prisma.response.findUnique({
+      where: {
+        guildId_keyword: {
+          guildId: guildId,
+          keyword: keyword,
+        },
+      },
+    });
+    return response?.response;
+  }
+
+  async registerResponseAsync(
+    keyword: string,
+    response: string,
+    guildId: string,
+  ): Promise<boolean> {
+    return await prisma.$transaction(async (prisma) => {
+      const existing = await prisma.response.findUnique({
+        where: {
+          guildId_keyword: {
+            keyword: keyword,
+            guildId: guildId,
+          },
+        },
+      });
+      if (existing) return false;
+      await prisma.response.create({
+        data: {
+          guildId: guildId,
+          keyword: keyword,
+          response: response,
+        },
+      });
+      return true;
+    });
+  }
+
+  async unregisterResponseAsync(
+    keyword: string,
+    guildId: string,
+  ): Promise<boolean> {
+    try {
+      await prisma.response.delete({
+        where: {
+          guildId_keyword: {
+            keyword: keyword,
+            guildId: guildId,
+          },
+        },
+      });
+    } catch (e) {
+      return false;
+    }
+    return true;
+  }
+
+  async upsertResponseAsync(
+    keyword: string,
+    response: string,
+    guildId: string,
+  ): Promise<void> {
+    await prisma.response.upsert({
+      where: {
+        guildId_keyword: {
+          keyword: keyword,
+          guildId: guildId,
+        },
+      },
+      update: {
+        response: response,
+      },
+      create: {
+        guildId: guildId,
+        keyword: keyword,
+        response: response,
+      },
+    });
+  }
+}
+
+export { type ICustomResponseService, CustomResponseService };

--- a/bot/src/services/Minecraft/index.ts
+++ b/bot/src/services/Minecraft/index.ts
@@ -20,7 +20,9 @@ class MinecraftService implements IMinecraftService {
         }),
       });
     } catch (e) {
-      console.error(e);
+      if (e instanceof AggregateError) {
+        console.log('[Minecraft] Cant connect to server');
+      }
     }
   }
 }


### PR DESCRIPTION
## コマンド
`/customresponse add <keyword> <response> [update]`
keyword に対するレスポンス response を設定します。update を True に設定した場合、既存のカスタムレスポンスを上書きする形で設定します。

`/customresponse delete <keyword>`
keyword に対して設定されているカスタムレスポンスを削除します。